### PR TITLE
fix(ci): move runner.temp out of job-level env

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -116,9 +116,6 @@ jobs:
       # Clear RUSTFLAGS so cargo-tauri's default flags don't break proc-macro
       # linking (ctor-proc-macro "can't find crate" error on Rust 1.89).
       RUSTFLAGS: ""
-      # The builder caches only hash-verified source/build directories. It never
-      # caches the target-qualified binaries copied into src-tauri/binaries.
-      VERBOO_MEDIA_SIDECAR_CACHE: ${{ runner.temp }}/verboo-media-sidecars-cache
 
     steps:
       - name: Checkout repository
@@ -194,11 +191,18 @@ jobs:
 
       - name: Build pinned media sidecars
         if: runner.os != 'Windows'
+        env:
+          # The builder caches only hash-verified source/build directories. It
+          # never caches the target-qualified binaries in src-tauri/binaries.
+          # (runner.* is a step-level context; job-level env rejects it.)
+          VERBOO_MEDIA_SIDECAR_CACHE: ${{ runner.temp }}/verboo-media-sidecars-cache
         run: npm run build:media-sidecars -- --target ${{ matrix.target }}
 
       - name: Build pinned media sidecars (Windows)
         if: runner.os == 'Windows'
         shell: msys2 {0}
+        env:
+          VERBOO_MEDIA_SIDECAR_CACHE: ${{ runner.temp }}/verboo-media-sidecars-cache
         run: node scripts/tauri/build-media-sidecars.mjs --target ${{ matrix.target }}
 
       - name: Verify target-qualified media sidecars


### PR DESCRIPTION
The `runner` context is not allowed in job-level `env`, so GitHub rejected the entire workflow file at queue time — every run failed in 0s with "workflow file issue" and no release build could start (this is why v0.5.2-beta.1 produced no artifacts). The media-sidecar cache path moves to step-level `env` on the two builder steps, where `runner.temp` is valid. Verified with actionlint.

