### PR TITLE
fix(ci): install media sidecar build toolchain per OS

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -141,14 +141,23 @@ jobs:
         with:
           msystem: MINGW64
           update: true
+          # inherit gives the MSYS2 shell the Windows PATH (setup-node's
+          # node.exe); without it the sidecar builder dies with
+          # "node: command not found".
+          path-type: inherit
           install: >-
             mingw-w64-x86_64-toolchain
             mingw-w64-x86_64-cmake
             mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-nasm
             autoconf
             automake
             libtool
             make
+
+      - name: Install macOS media build toolchain
+        if: runner.os == 'macOS'
+        run: brew install autoconf automake libtool nasm
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
@@ -166,7 +175,8 @@ jobs:
             pkg-config \
             autoconf \
             automake \
-            libtool
+            libtool \
+            nasm
 
       - name: Install npm dependencies
         run: npm ci


### PR DESCRIPTION
First real run of the release matrix surfaced three per-OS gaps building the pinned media sidecars: macOS runners lack autotools (zimg `autogen.sh` fails) and nasm; Ubuntu lacks nasm (FFmpeg configure aborts with 'nasm not found'); and the MSYS2 step shell did not inherit the Windows PATH, so `node` was not found. This installs autoconf/automake/libtool/nasm on macOS, adds nasm to the apt and MSYS2 package lists, and sets `path-type: inherit` on setup-msys2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)