### PR TITLE
fix(ci): add gettext-devel to the MSYS2 toolchain

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -154,6 +154,7 @@ jobs:
             automake
             libtool
             make
+            gettext-devel
 
       - name: Install macOS media build toolchain
         if: runner.os == 'macOS'


### PR DESCRIPTION
Windows round 4: extraction now works via System32 bsdtar; zimg's `autoreconf` then aborts because aclocal cannot find gettext's `progtest.m4`, which ships in the msys `gettext-devel` package. Adds it to the MSYS2 install list — the last missing piece of the Windows sidecar toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)