### PR TITLE
fix(build): re-export PKG_CONFIG_PATH inside the login shell

### DIFF
--- a/scripts/tauri/build-media-sidecars.mjs
+++ b/scripts/tauri/build-media-sidecars.mjs
@@ -65,11 +65,16 @@ function unixBuildCommand(commandName, args, options = {}) {
   const posixCommand = toPosixPath(commandName)
   const cwd = options.cwd ?? repositoryRoot
   const environment = { ...(options.env ?? process.env) }
-  if (environment.PKG_CONFIG_PATH) environment.PKG_CONFIG_PATH = toPosixPath(environment.PKG_CONFIG_PATH)
   environment.CHERE_INVOKED = '1'
+  // A login shell (-l) is required for the perl autotools to derive their
+  // prefix correctly, but /etc/profile RESETS PKG_CONFIG_PATH. Carry it in a
+  // profile-safe custom var and re-export it inside, after profile has run.
+  if (environment.PKG_CONFIG_PATH) {
+    environment.VERBOO_PKG_CONFIG_PATH = toPosixPath(environment.PKG_CONFIG_PATH)
+  }
   inheritedCommand('bash', [
     '-leo', 'pipefail',
-    '-c', 'cd "$0" && exec "$@"',
+    '-c', 'cd "$0" && { [ -n "$VERBOO_PKG_CONFIG_PATH" ] && export PKG_CONFIG_PATH="$VERBOO_PKG_CONFIG_PATH"; }; exec "$@"',
     toPosixPath(cwd), posixCommand, ...posixArgs,
   ], { env: environment })
 }


### PR DESCRIPTION
Round 7 got zimg building on Windows (login shell fixed the autotools prefix); ffmpeg's configure then failed with `zimg >= 2.7.0 not found using pkg-config` because the login shell sources `/etc/profile`, which resets `PKG_CONFIG_PATH`. The path is now carried in a profile-safe `VERBOO_PKG_CONFIG_PATH` and re-exported inside the `-c` script after profile has run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)