### PR TITLE
fix(build): Windows joins Linux with no guaranteed H.264 encoder

### DIFF
--- a/docs/licenses/video-media-sidecars.md
+++ b/docs/licenses/video-media-sidecars.md
@@ -25,9 +25,10 @@ FFmpeg is configured with the following fixed flags on every target:
 
 zimg is built as a static dependency, enabling FFmpeg's `zscale` and `tonemap`
 filters for explicit HDR-to-SDR conversion. macOS additionally enables the
-non-GPL `h264_videotoolbox` encoder; Windows enables `h264_mf`. Linux deliberately
-does not promise an H.264 encoder: incompatible originals are sampled into frames
-instead of being turned into a synthetic proxy.
+non-GPL `h264_videotoolbox` encoder. Neither Windows nor Linux promises a
+guaranteed H.264 encoder (Windows' `h264_mf` needs Media Foundation, which the
+minimal LGPL mingw build cannot link): on those platforms an incompatible
+original is sampled into frames instead of being turned into a synthetic proxy.
 
 The FFmpeg configuration disables GPL, nonfree, network, and automatic external
 library discovery. This keeps the shipped FFmpeg build under LGPL-2.1-or-later,

--- a/scripts/tauri/build-media-sidecars.mjs
+++ b/scripts/tauri/build-media-sidecars.mjs
@@ -163,7 +163,10 @@ export function requiredFfmpegCapabilities(target) {
   assertSupportedTarget(target)
   const encoders = ['png', 'pcm_s16le', 'aac']
   if (targetPlatform(target) === 'darwin') encoders.push('h264_videotoolbox')
-  if (isWindowsTarget(target)) encoders.push('h264_mf')
+  // Windows deliberately ships no guaranteed H.264 encoder: h264_mf needs
+  // Media Foundation, which the minimal LGPL mingw build cannot link. Like
+  // Linux, Windows falls back to sampled frames; the runtime toolchain probe
+  // (router.rs) reports the encoder as unavailable and routes accordingly.
   return {
     encoders,
     filters: [
@@ -411,7 +414,6 @@ async function buildFfmpeg(source, target, zimgPrefix, staging) {
   if (targetPlatform(target) === 'darwin') {
     configure.push('--enable-videotoolbox', '--enable-encoder=h264_videotoolbox')
   }
-  if (isWindowsTarget(target)) configure.push('--enable-encoder=h264_mf')
   const environment = buildEnvironment(target, {
     PKG_CONFIG_PATH: path.join(zimgPrefix, 'lib', 'pkgconfig'),
   })

--- a/scripts/tauri/build-media-sidecars.test.mjs
+++ b/scripts/tauri/build-media-sidecars.test.mjs
@@ -108,9 +108,10 @@ test('requires static whisper and the exact FFmpeg capabilities for each target'
     ['encoder: png'],
   )
 
+  // Windows joins Linux in promising no guaranteed H.264 encoder: h264_mf
+  // needs Media Foundation, which the minimal LGPL mingw build cannot link.
   const windows = requiredFfmpegCapabilities('x86_64-pc-windows-msvc')
-  assert.ok(windows.encoders.includes('h264_mf'))
-  assert.ok(!windows.encoders.includes('h264_videotoolbox'))
+  assert.ok(!windows.encoders.some((encoder) => encoder.startsWith('h264_')))
   const linux = requiredFfmpegCapabilities('x86_64-unknown-linux-gnu')
   assert.ok(!linux.encoders.some((encoder) => encoder.startsWith('h264_')))
 


### PR DESCRIPTION
The Windows sidecar chain now builds end to end — zimg compiles, ffmpeg's configure finds it, ffmpeg fully compiles — and the only remaining gate was the `h264_mf` capability check. `h264_mf` needs Media Foundation, which the minimal LGPL mingw toolchain cannot link. Rather than fight MF linking for an encoder the v1 pipeline never uses (the SDR proxy route is behind a CLI capability gate that is currently false), Windows now follows the same documented stance as Linux: no guaranteed H.264 encoder, incompatible originals are sampled into frames. The runtime toolchain probe in router.rs already reports the encoder as unavailable and routes to sampled frames. Drops `h264_mf` from the required capabilities and configure flags, updates the licensing note and the capability test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)