### PR TITLE
fix(build): raise spawnSync buffer for objdump probe

### DIFF
--- a/scripts/tauri/build-media-sidecars.mjs
+++ b/scripts/tauri/build-media-sidecars.mjs
@@ -36,6 +36,9 @@ function command(commandName, args, options = {}) {
     cwd: repositoryRoot,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
+    // objdump -p on a statically linked ffmpeg.exe far exceeds the 1 MiB
+    // spawnSync default (ENOBUFS); 64 MiB covers every probe output.
+    maxBuffer: 64 * 1024 * 1024,
     ...options,
   })
   if (result.error) throw result.error


### PR DESCRIPTION
The entire Windows sidecar chain now builds cleanly (zimg, ffmpeg, whisper-cli, strips all succeed). The final failure was the static-linkage probe: `objdump -p` on the statically linked `ffmpeg.exe` produces output far past spawnSync's 1 MiB default, so it died with `ENOBUFS`. Raises `maxBuffer` to 64 MiB for the shared `command()` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)