### PR TITLE
fix(build): disable OpenMP in whisper to drop libgomp

### DIFF
--- a/scripts/tauri/build-media-sidecars.mjs
+++ b/scripts/tauri/build-media-sidecars.mjs
@@ -132,6 +132,10 @@ export function whisperCmakeArguments(target) {
     '-DBUILD_SHARED_LIBS=OFF',
     '-DGGML_STATIC=ON',
     '-DGGML_BACKEND_DL=OFF',
+    // OpenMP pulls a dynamic libgomp-1.dll on mingw that breaks the fully
+    // static requirement; ggml's own pthread thread pool covers short-audio
+    // transcription without it.
+    '-DGGML_OPENMP=OFF',
     ...staticLinkerArguments(target).cmake,
   ]
 }

--- a/scripts/tauri/build-media-sidecars.test.mjs
+++ b/scripts/tauri/build-media-sidecars.test.mjs
@@ -91,6 +91,7 @@ test('requires static whisper and the exact FFmpeg capabilities for each target'
     '-DBUILD_SHARED_LIBS=OFF',
     '-DGGML_STATIC=ON',
     '-DGGML_BACKEND_DL=OFF',
+    '-DGGML_OPENMP=OFF',
   ])
 
   const macos = requiredFfmpegCapabilities('aarch64-apple-darwin')


### PR DESCRIPTION
With the objdump buffer fixed, the static-linkage probe ran and caught a genuine issue: `whisper-cli.exe` links `libgomp-1.dll` dynamically because ggml enables OpenMP by default and mingw does not static-link libgomp. `-DGGML_OPENMP=OFF` removes the dependency; ggml's own pthread thread pool handles short-audio transcription without measurable loss. Applied to all targets for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)