### PR TITLE
fix(ci): bake the published Chrome extension id into release builds

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -116,6 +116,12 @@ jobs:
       # Clear RUSTFLAGS so cargo-tauri's default flags don't break proc-macro
       # linking (ctor-proc-macro "can't find crate" error on Rust 1.89).
       RUSTFLAGS: ""
+      # Published Chrome Web Store identity, read at compile time by
+      # option_env! (chrome_integration/models.rs, native_host.rs). Without
+      # these the shipped app reports "this build has no production extension
+      # metadata" and the integration cannot be configured.
+      VERBOO_CHROME_EXTENSION_ID: "nkfgdaoblgcbngpklgnmjkfdabpbmpee"
+      VERBOO_CHROME_WEB_STORE_URL: "https://chromewebstore.google.com/detail/nkfgdaoblgcbngpklgnmjkfdabpbmpee"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The Verboo extension is now published (`nkfgdaoblgcbngpklgnmjkfdabpbmpee`), but the shipped app reports "this build has no production extension metadata" and refuses to configure the integration.

Cause: the id is read at **compile time** via `option_env!` (`chrome_integration/models.rs`, `verboo-in-chrome/src/native_host.rs`), and only the local `scripts/build-release-app.sh` exported it. The release matrix never did, so every distributed binary compiled with `None`.

Adds `VERBOO_CHROME_EXTENSION_ID` and `VERBOO_CHROME_WEB_STORE_URL` to the build job env so released builds carry the published identity.

Note: this fixes app→Chrome control (native MCP bridge, which carries no OAuth token). Standalone chat *inside* the extension side panel remains fail-closed until the Verboo backend registers a Chrome-extension OAuth public client for `https://nkfgdaoblgcbngpklgnmjkfdabpbmpee.chromiumapp.org/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)