### PR TITLE
fix(chrome): authenticate the MCP CLI runner

### DIFF
--- a/src-tauri/src/services/chrome_integration/cli_mcp.rs
+++ b/src-tauri/src/services/chrome_integration/cli_mcp.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 
 use serde_json::Value;
 
+use crate::services::auth_token::{augment_identity_env, inject_api_key, resolve_token};
 use crate::services::cli_spawn::CliSpawn;
+use crate::services::credentials_store::CredentialsStore;
 
 use super::paths::ChromeIntegrationPaths;
 
@@ -38,7 +40,15 @@ pub(crate) struct RealCliMcpRunner;
 
 impl CliMcpRunner for RealCliMcpRunner {
     fn run(&self, args: &[String]) -> Result<CliRunOutput, String> {
-        let output = CliSpawn::new(args)
+        let mut spawn = CliSpawn::new(args);
+        // Without the parent's credentials the CLI answers every subcommand
+        // with "not authenticated" and prints no JSON, so `mcp doctor` was
+        // read as an invalid config and configuration failed with a generic
+        // error. Mirror the turn spawn: identity env plus the resolved token.
+        augment_identity_env(&mut spawn.command);
+        let credentials = CredentialsStore::new();
+        let _guard = inject_api_key(resolve_token(&credentials).as_deref(), &mut spawn.command);
+        let output = spawn
             .command
             .output()
             .map_err(|error| error.to_string())?;


### PR DESCRIPTION
With the published extension id now baked in (#56), "Configurar" still failed with the generic "Não foi possível concluir esta ação".

Root cause: `RealCliMcpRunner` spawned the bundled CLI through `CliSpawn` **without injecting credentials**, unlike `turn_service`. Every `mcp doctor --config-only --json` therefore answered *"Não autenticado no Verboo…"* with no JSON on stdout, `contains_json_value` returned false, the state resolved to `CliMcpState::Invalid`, and `ensure_mcp_registered` bailed with `chrome_mcp_invalid`.

Same class of bug as the goal-evaluator authentication issue: a CLI spawn path that forgot the parent must supply the token. The runner now calls `augment_identity_env` + `inject_api_key(resolve_token(...))`, exactly like the turn spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)