### PR TITLE
fix(chrome): name the MCP server before the env flags

### DIFF
--- a/src-tauri/src/services/chrome_integration/cli_mcp.rs
+++ b/src-tauri/src/services/chrome_integration/cli_mcp.rs
@@ -118,16 +118,19 @@ pub(crate) fn add(
     helper_path: &Path,
     version: &str,
 ) -> Result<(), String> {
+    // `-e/--env` is variadic: any positional that follows it is swallowed as
+    // another env var ("Invalid environment variable format: verboo-in-chrome").
+    // The server name must therefore come before the flags.
     let args = vec![
         "mcp".into(),
         "add".into(),
+        MCP_NAME.into(),
         "--scope".into(),
         "user".into(),
         "-e".into(),
         format!("{MANAGED_MARKER}=1"),
         "-e".into(),
         format!("{VERSION_MARKER}={version}"),
-        MCP_NAME.into(),
         "--".into(),
         helper_path.to_string_lossy().into_owned(),
         "mcp".into(),

--- a/src-tauri/src/services/chrome_integration/tests.rs
+++ b/src-tauri/src/services/chrome_integration/tests.rs
@@ -140,6 +140,24 @@ impl CliMcpRunner for FakeCliRunner {
                 stderr: String::new(),
             }),
             Some("add") => {
+                // The real CLI parses `-e/--env` as variadic, so a positional
+                // that follows it is swallowed as another env var. Reproduce
+                // that here: the server name must precede every flag.
+                let name_index = args
+                    .iter()
+                    .position(|arg| arg == "verboo-in-chrome")
+                    .expect("mcp add must name the server");
+                let first_flag = args
+                    .iter()
+                    .position(|arg| arg.starts_with('-') && arg != "--")
+                    .unwrap_or(usize::MAX);
+                if name_index > first_flag {
+                    return Ok(CliRunOutput {
+                        success: false,
+                        stdout: String::new(),
+                        stderr: "Invalid environment variable format: verboo-in-chrome".into(),
+                    });
+                }
                 let separator = args.iter().position(|arg| arg == "--").unwrap();
                 let helper = &args[separator + 1];
                 let version = args


### PR DESCRIPTION
Final blocker for "Verboo no Chrome". With the extension id baked in (#56) and the runner authenticated (#57), Configure still failed with the generic "Não foi possível concluir esta ação".

Captured the real error by logging the failure instead of swallowing it:

```
chrome_cli_command_failed: Invalid environment variable format: verboo-in-chrome,
environment variables should be added as: -e KEY1=value1 -e KEY2=value2
```

`verboo mcp add` declares `-e, --env <env...>` as **variadic**, so the positional server name that followed the env flags was parsed as another env var. Verified against the bundled CLI:

- `mcp add --scope user -e K=1 -e K2=2 name -- cmd` → fails
- `mcp add name --scope user -e K=1 -e K2=2 -- cmd` → succeeds

The name now comes first. The fake runner in tests also reproduces the variadic behaviour, so the ordering is covered — reverting the fix makes two existing tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)