### PR TITLE
fix(chrome): keep retrying the native bridge

### DIFF
--- a/extensions/verboo-chrome/manifest.json
+++ b/extensions/verboo-chrome/manifest.json
@@ -3,8 +3,8 @@
   "name": "__MSG_appName__",
   "short_name": "Verboo",
   "description": "__MSG_appDesc__",
-  "version": "0.1.0",
-  "version_name": "0.1.0-p1",
+  "version": "0.1.1",
+  "version_name": "0.1.1-p4",
   "default_locale": "en",
   "minimum_chrome_version": "123",
   "icons": {

--- a/extensions/verboo-chrome/src/native/bridge.js
+++ b/extensions/verboo-chrome/src/native/bridge.js
@@ -2,6 +2,7 @@ export const NATIVE_MESSAGING_HOST_NAME = 'com.verboo.code.browser_extension'
 export const BROWSER_BRIDGE_PROTOCOL_VERSION = 1
 
 const DEFAULT_RECONNECT_DELAY_MS = 750
+const MAX_RECONNECT_DELAY_MS = 30_000
 
 /**
  * @param {{
@@ -23,8 +24,25 @@ export function createNativeBridge({
 }) {
   let port = null
   let stopped = false
-  let reconnectUsed = false
   let startupRegistered = false
+  let reconnectAttempt = 0
+  let reconnectTimer = null
+
+  // The host only exists after the desktop app configures the integration.
+  // A single retry meant an extension installed before that step gave up
+  // forever, so reconnection now backs off but never stops trying.
+  function scheduleReconnect() {
+    if (stopped || reconnectTimer) return
+    const delay = Math.min(
+      reconnectDelayMs * 2 ** reconnectAttempt,
+      MAX_RECONNECT_DELAY_MS,
+    )
+    reconnectAttempt += 1
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null
+      if (!stopped) connect()
+    }, delay)
+  }
 
   function connect() {
     stopped = false
@@ -33,27 +51,36 @@ export function createNativeBridge({
       const nextPort = chromeApi.runtime.connectNative(NATIVE_MESSAGING_HOST_NAME)
       port = nextPort
       nextPort.onMessage.addListener((message) => {
+        // A real message proves the host is alive: restart the backoff.
+        reconnectAttempt = 0
         void handleMessage(nextPort, message)
       })
       nextPort.onDisconnect.addListener(() => {
         if (port !== nextPort) return
         port = null
-        if (!stopped && !reconnectUsed) {
-          reconnectUsed = true
-          setTimeout(() => {
-            if (!stopped) connect()
-          }, reconnectDelayMs)
+        const failure = chromeApi.runtime?.lastError
+        if (failure) {
+          console.warn('[verboo] native bridge disconnected:', failure.message)
         }
+        scheduleReconnect()
       })
       return true
-    } catch {
+    } catch (error) {
+      // Silent failure here hid the real cause (missing host, blocked
+      // executable) from anyone reading the service worker console.
+      console.warn('[verboo] connectNative failed:', error?.message ?? error)
       port = null
+      scheduleReconnect()
       return false
     }
   }
 
   function disconnect() {
     stopped = true
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
     const current = port
     port = null
     try {
@@ -67,7 +94,7 @@ export function createNativeBridge({
     if (startupRegistered) return
     startupRegistered = true
     chromeApi.runtime.onStartup.addListener(() => {
-      reconnectUsed = false
+      reconnectAttempt = 0
       connect()
     })
   }

--- a/extensions/verboo-chrome/src/native/bridge.test.js
+++ b/extensions/verboo-chrome/src/native/bridge.test.js
@@ -123,7 +123,9 @@ test('approval-required calls fail closed while the panel is unavailable', async
   assert.equal(ports[0].posted[0].payload.code, 'approval_ui_unavailable')
 })
 
-test('runtime startup connects and one disconnect gets one bounded reconnect', async () => {
+test('startup connects and every disconnect schedules another attempt', async () => {
+  // The host only exists once the desktop app configures the integration, so
+  // an extension installed first must keep retrying instead of giving up.
   const { bridge, chromeApi, ports } = fixture()
   bridge.registerStartup()
 
@@ -134,7 +136,22 @@ test('runtime startup connects and one disconnect gets one bounded reconnect', a
   assert.equal(ports.length, 2)
   ports[1].onDisconnect.emit()
   await tick()
-  assert.equal(ports.length, 2)
+  assert.equal(ports.length, 3)
+  ports[2].onDisconnect.emit()
+  await tick()
+  assert.equal(ports.length, 4)
+})
+
+test('an explicit disconnect stops the retry loop', async () => {
+  const { bridge, ports } = fixture()
+  bridge.connect()
+  assert.equal(ports.length, 1)
+
+  bridge.disconnect()
+  ports[0].onDisconnect.emit()
+  await tick()
+
+  assert.equal(ports.length, 1)
 })
 
 test('a disconnected in-flight request is never replayed onto a new port', async () => {


### PR DESCRIPTION
Diagnosing why "Verboo no Chrome" reported *Aguardando o Chrome* after everything on the app side was verified working (host manifest correct, helper executable — proved by invoking it exactly as Chrome does, MCP entry registered, extension installed from the store with the matching id and nativeMessaging permission), the remaining gap was the extension never opening the native port.

Two real defects in `src/native/bridge.js`:

1. **Single-shot reconnect.** `reconnectUsed` was latched after one retry and only reset on `chrome.runtime.onStartup`. An extension installed *before* the desktop app configures the integration — the normal first-run order — fails twice, gives up, and never reconnects. Now the retry backs off (750ms doubling to a 30s ceiling) and keeps going, resetting the backoff once the host answers a message.

2. **Silent failure.** The `catch` was empty and the disconnect handler never read `chrome.runtime.lastError`, so the service worker console showed nothing at all — which is why this took so long to pin down. Both paths now log the real cause.

Tests updated to the new contract (retry persists; an explicit `disconnect()` stops the loop). 204 extension tests pass. Packaged as `0.1.1-p4` for the store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)